### PR TITLE
Prevent htmlEncode() and htmlDecode() from converting blank strings into empty strings

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -34,7 +34,7 @@ exports.Encoder = function(type) {
         // Numerically encodes all unicode characters
         numEncode : function(s) {
 
-            if (this.isEmpty(s)) return "";
+            if (this.isEmpty(s)) return s;
 
             var e = "";
             for (var i = 0; i < s.length; i++) {
@@ -52,7 +52,7 @@ exports.Encoder = function(type) {
 
             var arr,c,m,d = s;
 
-            if (this.isEmpty(d)) return "";
+            if (this.isEmpty(d)) return d;
 
             // convert HTML entites back to numerical entites first
             d = this.HTML2Numerical(d);
@@ -81,7 +81,7 @@ exports.Encoder = function(type) {
         // encode an input string into either numerical or HTML entities
         htmlEncode : function(s, dbl) {
 
-            if (this.isEmpty(s)) return "";
+            if (this.isEmpty(s)) return s;
 
             // do we allow double encoding? E.g will &amp; be turned into &amp;amp;
             dbl = dbl || false; //default to prevent double encoding
@@ -158,7 +158,7 @@ exports.Encoder = function(type) {
                 }
                 return s;
             } else {
-                return "";
+                return s;
             }
         },
 
@@ -187,7 +187,7 @@ exports.Encoder = function(type) {
 
         // Function to loop through an array swaping each item with the value from another array e.g swap HTML entities with Numericals
         swapArrayVals : function(s, arr1, arr2) {
-            if (this.isEmpty(s)) return "";
+            if (this.isEmpty(s)) return s;
             var re;
             if (arr1 && arr2) {
                 //ShowDebug("in swapArrayVals arr1.length = " + arr1.length + " arr2.length = " + arr2.length)
@@ -212,4 +212,3 @@ exports.Encoder = function(type) {
         }
     }
 }
-


### PR DESCRIPTION
Generally, when no characters need to be encoded, `htmlEncode()` returns input string.  For example,

```
encoder.htmlEncode("Foo")
```

yields

```
"Foo"
```

This holds true even when the input string has leading or trailing whitespace.  For example,

```
encoder.htmlEncode("   Foo ")
```

yields

  "   Foo "

But when the input string is comprised entirely of whitespace, `htmlEncode()` always returns a blank string, rather than the original input string.

For example,

```
encoder.htmlEncode(" ")
```

yields

```
""
```

or

```
encoder.htmlEncode("     ")
```

also yields

```
""
```

I think we'd like to see the encoder return the orginal string in these cases.

`htmlDecode()` has the same problem.

```
encoder.htmlDecode("Foo")
```

yields

```
"Foo"
```

And

```
encoder.htmlDecode("   Foo ")
```

yields

```
"   Foo "
```

But

```
encoder.htmlDecode(" ")
```

yields

```
""
```

and

```
encoder.htmlDecode("     ")
```

yields

```
""
```

This is easy to fix.  Rather than something like

```
if(this.isBlank(str)) { return ''; }
```

we should use

```
if(this.isBlank(str)) { return str; }
```

When the input string was truly empty, the behavior doesn't change, but when given a non-empty but blank string (one comprised entirely of whitespace), now we get back the orginal string, unchanged.

It doesn't look like any of the code depends on `htmlEncode` and `htmlDecode` reducing blank strings to empty ones, so I believe this is safe change to make.

There doesn't seem to be a test suite for node-html-encoder (yet?) and I didn't want to take the liberty of adding one for this small patch, but I posted a small script that demonstrates the issue at https://gist.github.com/rodw/4736648#file-example-js
